### PR TITLE
ci: composer cache doesn't change anything

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,12 +48,6 @@ jobs:
       - name: Create second test database
         run: mysql --host 127.0.0.1 --port 3306 -uroot -e "CREATE DATABASE IF NOT EXISTS custom_database;"
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
The current cache path is invalid since Composer 2. We could update it, but there is not significant performance gains since we don't have a `composer.lock`, so I think it's better to just remove it for now.